### PR TITLE
Feat/track light dark

### DIFF
--- a/Mora/CHANGELOG.md
+++ b/Mora/CHANGELOG.md
@@ -1,0 +1,9 @@
+# 2024-07-21
+## ADDED
+### - `calculate_dark_phase_from_timestamp()` in `update_objects.py`
+### - New `dark_phase` column in export
+
+# 2024-07-20
+## ADDED
+### - `LightDark_Dialog()` to record beginninng and end of dark phases 
+### - `getDarkStartEnd` to store dark start and end times

--- a/Mora/initialize_objects.py
+++ b/Mora/initialize_objects.py
@@ -20,6 +20,7 @@ class General(QWidget):
         self.TIMESTAMP_FORMAT_EXPORTING = "%Y-%m-%d %H:%M:%S"
 
         # Dark Period start and end times
+        self.LightDark_input = False
         self.DarkTimeStart = None
         self.DarkTimeEnd = None
 
@@ -88,7 +89,7 @@ class LightDark_Dialog(QDialog):
     def validateDarkStartEnd(self):
         if (
             not self.DarkTimeStart.dateTime().toPyDateTime()
-            > self.DarkTimeEnd.dateTime().toPyDateTime()
+            < self.DarkTimeEnd.dateTime().toPyDateTime()
         ):
             raise ValueError("Start of dark phase must come before end of dark period")
 

--- a/Mora/initialize_objects.py
+++ b/Mora/initialize_objects.py
@@ -14,9 +14,14 @@ class General(QWidget):
         self.current_path = os.path.dirname(os.path.realpath(__file__))
 
         # Timestamp
+        self.timestamp_selected = False
         self.timestamp = None
         self.TIMESTAMP_FORMAT_PLOTTING = "%Y-%m-%d\n%H:%M:%S"
         self.TIMESTAMP_FORMAT_EXPORTING = "%Y-%m-%d %H:%M:%S"
+
+        # Dark Period start and end times
+        self.DarkTimeStart = None
+        self.DarkTimeEnd = None
 
 
 class Timestamp_Dialog(QDialog):
@@ -43,6 +48,49 @@ class Timestamp_Dialog(QDialog):
 
     def getDateTime(self):
         return self.dateTimeEdit.dateTime()
+
+
+class LightDark_Dialog(QDialog):
+    def __init__(self):
+        super().__init__()
+
+        self.setWindowTitle("Start and End Time of Dark periods")
+        self.setGeometry(100, 100, 500, 100)
+
+        layout = QVBoxLayout()
+        start_time_label = QLabel("Enter start time of dark period")
+        self.DarkTimeStart = QDateTimeEdit(self)
+        self.DarkTimeStart.setDateTime(QDateTime.currentDateTime())
+        self.DarkTimeStart.setDisplayFormat("yyyy-MM-dd HH:mm:ss")
+        layout.addWidget(start_time_label)
+        layout.addWidget(self.DarkTimeStart)
+
+        end_time_label = QLabel("Enter end time of dark period")
+        self.DarkTimeEnd = QDateTimeEdit(self)
+        self.DarkTimeEnd.setDateTime(QDateTime.currentDateTime())
+        self.DarkTimeEnd.setDisplayFormat("yyyy-MM-dd HH:mm:ss")
+        layout.addWidget(end_time_label)
+        layout.addWidget(self.DarkTimeEnd)
+
+        self.buttonBox = QDialogButtonBox(
+            QDialogButtonBox.Ok | QDialogButtonBox.Cancel, self
+        )
+        self.buttonBox.accepted.connect(self.accept)
+        self.buttonBox.rejected.connect(self.reject)
+        layout.addWidget(self.buttonBox)
+
+        self.setLayout(layout)
+
+    def getDarkStartEnd(self):
+        self.validateDarkStartEnd()
+        return self.DarkTimeStart.dateTime(), self.DarkTimeEnd.dateTime()
+
+    def validateDarkStartEnd(self):
+        if (
+            not self.DarkTimeStart.dateTime().toPyDateTime()
+            > self.DarkTimeEnd.dateTime().toPyDateTime()
+        ):
+            raise ValueError("Start of dark phase must come before end of dark period")
 
 
 class Data(QWidget):

--- a/Mora/update_objects.py
+++ b/Mora/update_objects.py
@@ -1,6 +1,13 @@
 from PyQt5.QtWidgets import *
 from PyQt5.QtCore import Qt
-from initialize_objects import General, Home, Model, Data, Timestamp_Dialog
+from initialize_objects import (
+    General,
+    Home,
+    Model,
+    Data,
+    Timestamp_Dialog,
+    LightDark_Dialog,
+)
 import os
 import pandas as pd
 import numpy as np
@@ -8,7 +15,7 @@ from scipy.io import wavfile
 from data_processing import sleep_functions as sleep
 import pyqtgraph as pg
 from PyQt5.QtGui import QKeyEvent
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 
 class Funcs(QWidget):
@@ -20,6 +27,7 @@ class Funcs(QWidget):
         self.Model = Model()
         self.Data = Data()
         self.Timestamp_Dialog = Timestamp_Dialog()
+        self.LightDark_Dialog = LightDark_Dialog()
 
         # brushes for coloring scoring windows
         self.rem = pg.mkBrush(pg.intColor(90, alpha=50))
@@ -109,7 +117,7 @@ class Funcs(QWidget):
         ).T
         score_export.columns = ["epoch", "score"]
 
-        if self.General.timestamp:
+        if self.General.timestamp_index:
             score_export["timestamp"] = self.calculate_timestamp_from_epoch()
 
         score_export.to_csv(file_path + ".csv", sep=",", index=False)
@@ -210,6 +218,8 @@ class Funcs(QWidget):
         dialog = self.Timestamp_Dialog
         if dialog.exec_() == QDialog.Accepted:
             self.General.timestamp = dialog.getDateTime().toPyDateTime()
+            self.General.timestamp_selected = True
+            self.getDarkStartEnd()
         else:
             QMessageBox.information(
                 self, "Dialog Canceled", "No date and time selected."
@@ -223,6 +233,13 @@ class Funcs(QWidget):
             for key, value in xlabels.items()
         }
         return xlabels
+
+    def getDarkStartEnd(self):
+        dialog = self.LightDark_Dialog
+        if dialog.exec_() == QDialog.Accepted:
+            dark_start_time, dark_end_time = dialog.getDarkStartEnd()
+        self.General.DarkStartTime = dark_start_time.toPyDateTime()
+        self.General.DarkEndTime = dark_end_time.toPyDateTime()
 
     def load_data(self) -> None:
         path, ext = QFileDialog.getOpenFileName(


### PR DESCRIPTION
Adding feature to track light/dark cycle.

This implementation allows users to enter a start and end time for the dark cycle when loading the data. There is a single validation check to ensure that the end time is later than the start time.

This approach assumes only one dark cycle per recording.

The score export includes a column `dark_phase` that is 0 if false ans 1 if true.
